### PR TITLE
Cli command rebuild

### DIFF
--- a/src/pynuget/cli.py
+++ b/src/pynuget/cli.py
@@ -105,6 +105,16 @@ def main():
         action='store_true',
     )
 
+    # Rebuild
+    parser_rebuild = subparser.add_parser(
+        "rebuild",
+        help=("Rebuild the package database based on the files in"
+              " the package directory. Useful when manually adding or"
+              " removing NuGet package files."),
+        parents=[parent_parser],
+    )
+    parser_rebuild.set_defaults(func=run_rebuild)
+
     # Parse the args
     args = parser.parse_args()
 
@@ -127,3 +137,7 @@ def run_init(args):
 
 def run_clear(args):
     commands.clear(server_path=SERVER_PATH)
+
+
+def run_rebuild(args):
+    pass

--- a/src/pynuget/cli.py
+++ b/src/pynuget/cli.py
@@ -140,4 +140,4 @@ def run_clear(args):
 
 
 def run_rebuild(args):
-    pass
+    commands.rebuild()

--- a/src/pynuget/commands.py
+++ b/src/pynuget/commands.py
@@ -110,11 +110,7 @@ def rebuild():
     # TODO: create the session.
     logger.debug("Getting database packages and versions.")
     db_data = db.search_packages(session, include_prerelease=True)
-    # TODO: munge the data
-    # A dict of {'pkg_name': ['vers1', 'vers2']} should work pretty well
-    logger.debug("Found %d database packages." % len(db_data))
-    logger.debug("Found %d database versions." % sum(len(v) for v
-                                                     in db_data.values()))
+    db_data = _db_data_to_dict(db_data)
 
     # Then we'll get the list of all the packages in the package directory
     # Same data structure as the db data.
@@ -123,6 +119,25 @@ def rebuild():
 
     _add_packages_to_db(file_data)
     _remove_packages_from_db(file_data, db_data)
+
+
+def _db_data_to_dict(db_data):
+    """
+    Convert the result of db.search_packages into a dict of
+        {'pkg': ['vers1', 'vers2', ...]}
+    """
+    data = {}
+    for row in db_data:
+        try:
+            data[row.package.title]
+        except KeyError:
+            data[row.package.title] = []
+        data[row.package.title].append(row.version.version)
+
+    logger.debug("Found %d database packages." % len(data))
+    logger.debug("Found %d database versions." % sum(len(v) for v
+                                                     in data.values()))
+    return data
 
 
 def _get_packages_from_files(pkg_path):

--- a/src/pynuget/commands.py
+++ b/src/pynuget/commands.py
@@ -121,25 +121,8 @@ def rebuild():
     pkg_path = Path(config.SERVER_PATH) / Path(config.PACKAGE_DIR)
     file_data = _get_packages_from_files(pkg_path)
 
-    # Add new packages to the database.
-    for pkg, versions in file_data.items():
-        # TODO
-        # Check that the package exists in the database.
-        if not package_in_db(pkg):
-            add_to_db(pkg)
-
-        for version in versions:
-            if not version_in_db(pkg, version):
-                add_to_db(pkg, version)
-
-    # Remove missing packages from the database.
-    for pkg, versions in db_data.items():
-        if pkg not in file_data.keys():
-            remove_from_db(pkg):
-        else:
-            for version in versions:
-                if version not in file_data[pkg]:
-                    remove_from_db(pkg, version)
+    _add_packages_to_db(file_data)
+    _remove_packages_from_db(file_data, db_data)
 
 
 def _get_packages_from_files(pkg_path):
@@ -163,6 +146,30 @@ def _get_packages_from_files(pkg_path):
     logger.debug("Found %d versions." % sum(len(v) for v in data.values()))
 
     return data
+
+
+def _add_packages_to_db(file_data):
+    raise NotImplementedError
+    for pkg, versions in file_data.items():
+        # TODO
+        # Check that the package exists in the database.
+        if not package_in_db(pkg):
+            db.insert_or_update_package(session, None, pkg, versions[0])
+
+        for version in versions:
+            if not version_in_db(pkg, version):
+                db.insert_version(session, package_id=None, pkg, version)
+
+
+def _remove_packages_from_db(file_data, db_data):
+    raise NotImplementedError
+    for pkg, versions in db_data.items():
+        if pkg not in file_data.keys():
+            db.delete_version(pkg)
+        else:
+            for version in versions:
+                if version not in file_data[pkg]:
+                    db.delete_version(pkg, version)
 
 
 def _check_permissions():

--- a/src/pynuget/commands.py
+++ b/src/pynuget/commands.py
@@ -106,6 +106,7 @@ def clear(server_path, force=False):
 
 def rebuild():
     """Rebuild the package database."""
+    raise NotImplementedError
     import config
     # First let's get a list of all the packages in the database.
     # TODO: create the session.

--- a/src/pynuget/commands.py
+++ b/src/pynuget/commands.py
@@ -127,6 +127,7 @@ def rebuild():
 
 def _get_packages_from_files(pkg_path):
     """"""
+    logger.debug("Getting list of packages in package dir.")
     if not isinstance(pkg_path, Path):
         pkg_path = Path(pkg_path)
 
@@ -149,6 +150,7 @@ def _get_packages_from_files(pkg_path):
 
 
 def _add_packages_to_db(file_data):
+    logger.debug("Adding packages to database.")
     raise NotImplementedError
     for pkg, versions in file_data.items():
         # TODO
@@ -162,6 +164,7 @@ def _add_packages_to_db(file_data):
 
 
 def _remove_packages_from_db(file_data, db_data):
+    logger.debug("Removing packages from database.")
     raise NotImplementedError
     for pkg, versions in db_data.items():
         if pkg not in file_data.keys():

--- a/src/pynuget/commands.py
+++ b/src/pynuget/commands.py
@@ -126,7 +126,19 @@ def rebuild():
 
 
 def _get_packages_from_files(pkg_path):
-    """"""
+    """
+    Get a list of packages from the package directory.
+
+    Parameters
+    ----------
+    pkg_path : :class:`pathlib.Path` or str
+        The path to the package directory.
+
+    Returns
+    -------
+    data : dict
+        Dict of {'pkg_name': ['vers1', 'vers2', ...], ...}
+    """
     logger.debug("Getting list of packages in package dir.")
     if not isinstance(pkg_path, Path):
         pkg_path = Path(pkg_path)

--- a/src/pynuget/commands.py
+++ b/src/pynuget/commands.py
@@ -119,21 +119,7 @@ def rebuild():
     # Then we'll get the list of all the packages in the package directory
     # Same data structure as the db data.
     pkg_path = Path(config.SERVER_PATH) / Path(config.PACKAGE_DIR)
-    file_data = {}
-    # XXX: There's got to be a better way!
-    for root, dirs, _ in os.walk(str(pkg_path)):
-        rel_path = Path(root).relative_to(pkg_path)
-        pkg = str(rel_path.parent())
-        if pkg == '.':
-            # We're at a package-level item.
-            file_data[pkg] = []
-        else:
-            # We're looking at a version
-            file_data[pkg].append(rel_path.name)
-
-    logger.debug("Found %d packages." % len(file_data))
-    logger.debug("Found %d versions." % sum(len(v) for v
-                                            in file_data.values()))
+    file_data = _get_packages_from_files(pkg_path)
 
     # Add new packages to the database.
     for pkg, versions in file_data.items():
@@ -154,6 +140,29 @@ def rebuild():
             for version in versions:
                 if version not in file_data[pkg]:
                     remove_from_db(pkg, version)
+
+
+def _get_packages_from_files(pkg_path):
+    """"""
+    if not isinstance(pkg_path, Path):
+        pkg_path = Path(pkg_path)
+
+    data = {}
+    # XXX: There's got to be a better way!
+    for root, dirs, _ in os.walk(str(pkg_path)):
+        rel_path = Path(root).relative_to(pkg_path)
+        pkg = str(rel_path.parent)
+        if pkg != '.':
+            try:
+                data[pkg]
+            except KeyError:
+                data[pkg] = []
+            data[pkg].append(rel_path.name)
+
+    logger.debug("Found %d packages." % len(data))
+    logger.debug("Found %d versions." % sum(len(v) for v in data.values()))
+
+    return data
 
 
 def _check_permissions():

--- a/src/pynuget/commands.py
+++ b/src/pynuget/commands.py
@@ -106,6 +106,7 @@ def clear(server_path, force=False):
 
 def rebuild():
     """Rebuild the package database."""
+    import config
     # First let's get a list of all the packages in the database.
     # TODO: create the session.
     logger.debug("Getting database packages and versions.")
@@ -132,7 +133,7 @@ def _db_data_to_dict(db_data):
             data[row.package.title]
         except KeyError:
             data[row.package.title] = []
-        data[row.package.title].append(row.version.version)
+        data[row.package.title].append(row.version)
 
     logger.debug("Found %d database packages." % len(data))
     logger.debug("Found %d database versions." % sum(len(v) for v
@@ -187,7 +188,8 @@ def _add_packages_to_db(file_data):
 
         for version in versions:
             if not version_in_db(pkg, version):
-                db.insert_version(session, package_id=None, pkg, version)
+                db.insert_version(session, package_id=None, title=pkg,
+                                  version=version)
 
 
 def _remove_packages_from_db(file_data, db_data):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,6 +9,9 @@ import pytest
 
 from pynuget import commands
 from pynuget import app
+from pynuget import db
+
+from .test_db import session
 
 
 DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
@@ -40,3 +43,12 @@ def test__get_packages_from_files(package_data, package_dir):
     for key, value in data.items():
         assert key in package_data
         assert set(value) == set(package_data[key])
+
+
+def test__db_data_to_dict(session):
+    expected = {'dummy': ['0.0.1', '0.0.2', '0.0.3']}
+    data = db.search_packages(session, include_prerelease=True)
+    result = commands._db_data_to_dict(data)
+    for key, value in result.items():
+        assert key in expected
+        assert set(value) == set(expected[key])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+"""
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from pynuget import commands
+from pynuget import app
+
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
+
+
+@pytest.fixture
+def package_data():
+    """A dummy set of packages."""
+    data = {'PkgA': ['vers1', 'vers2', 'vers3'],
+            'PkgB': ['versionA', 'VersionB', '0.0.3'],
+            }
+    return data
+
+
+@pytest.fixture
+def package_dir(package_data):
+    """A dummy package directory with packages."""
+    pkg_dir = Path(DATA_DIR) / Path('pkgs')
+    for pkg, versions in package_data.items():
+        for version in versions:
+            path = pkg_dir / Path(pkg) / Path(version)
+            os.makedirs(str(path), exist_ok=True)
+    yield pkg_dir
+    shutil.rmtree(str(pkg_dir), ignore_errors=False)
+
+
+def test__get_packages_from_files(package_data, package_dir):
+    data = commands._get_packages_from_files(package_dir)
+    for key, value in data.items():
+        assert key in package_data
+        assert set(value) == set(package_data[key])


### PR DESCRIPTION
Adds the start of the cli command `rebuild` which will rebuild (aka repair) the database from the package directory by removing not-found packages and adding missing packages.