### PR TITLE
Cleanup db

### DIFF
--- a/src/pynuget/commands.py
+++ b/src/pynuget/commands.py
@@ -131,10 +131,10 @@ def _db_data_to_dict(db_data):
     data = {}
     for row in db_data:
         try:
-            data[row.package.title]
+            data[row.package.name]
         except KeyError:
-            data[row.package.title] = []
-        data[row.package.title].append(row.version)
+            data[row.package.name] = []
+        data[row.package.name].append(row.version)
 
     logger.debug("Found %d database packages." % len(data))
     logger.debug("Found %d database versions." % sum(len(v) for v

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -196,14 +196,6 @@ def find_by_id(session, package_name, version=None):
     return query.all()
 
 
-def parse_order_by():
-    raise NotImplementedError
-
-
-def do_search():
-    raise NotImplementedError
-
-
 def validate_id_and_version(session, package_name, version):
     """
     Not exactly sure what this is supposed to do, but I *think* it simply
@@ -317,8 +309,3 @@ def delete_version(session, package_name, version):
     else:
         session.delete(package)
     session.commit()
-
-
-# XXX: I don't think this is actually needed, since SQLAlchemy does it.
-def build_in_clause():
-    raise NotImplementedError

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -86,7 +86,17 @@ class Version(Base):
 
 
 def count_packages(session):
-    """Count the number of packages on the server."""
+    """
+    Count the number of packages on the server.
+
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.session.Session`
+
+    Returns
+    -------
+    int
+    """
     logger.debug("db.count_packages()")
     return session.query(func.count(Package.package_id)).scalar()
 
@@ -96,6 +106,16 @@ def search_packages(session,
                     order_by=desc(Version.version_download_count),
                     filter_=None,
                     search_query=None):
+    """
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.session.Session`
+    include_prerelease : bool
+    order_by : :class:`sqlalchemy.sql.operators.ColumnOperators`
+    filder_ : str
+        One of ('is_absolute_latest_version', 'is_latest_version').
+    search_query : str
+    """
     logger.debug("db.search_packages(...)")
     query = session.query(Version).join(Package)
 
@@ -135,8 +155,10 @@ def package_updates(session, packages_dict, include_prerelease=False):
 
     Parameters
     ----------
+    session : :class:`sqlalchemy.orm.session.Session`
     packages_dict : dict
-        Dict of {package_id, version}.
+        Dict of {package.name, version}.
+    include_prerelease : bool
     """
     logger.debug("db.package_updates(...)")
     package_versions = ["{}~~{}".format(pkg, vers)
@@ -186,7 +208,15 @@ def validate_id_and_version(session, package_name, version):
     """
     Not exactly sure what this is supposed to do, but I *think* it simply
     makes sure that the given pacakge_id and version exist... So that's
-    what I've decided to make it do."""
+    what I've decided to make it do.
+
+    Parameters
+    ----------
+    session : :class:`sqlalchemy.orm.session.Session`
+    package_name : str
+        The NuGet name of the package - the "id" tag in the NuSpec file.
+    version : str
+    """
     logger.debug("db.validate_id_and_version(...)")
     query = (session.query(Version)
              .filter(Package.name == package_name)

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -47,7 +47,8 @@ class Version(Base):
     __tablename__ = "version"
 
     version_id = Column(Integer, primary_key=True)
-    package_id = Column(Integer, ForeignKey("package.package_id"))
+    package_id = Column(Integer, ForeignKey("package.package_id"),
+                        nullable=False)
     title = Column(Text())
     description = Column(Text())
     created = Column(Integer)
@@ -79,7 +80,9 @@ class Version(Base):
 
     @thing.expression
     def thing(cls):
-        return cast(cls.package_id, String) + "~~" + cast(cls.version, String)
+        name = cast(cls.package_id, String)
+        version = cast(cls.version, String)
+        return name + "~~" + version
 
 
 def count_packages(session):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -112,16 +112,6 @@ def test_find_by_id(session):
     assert result_2[0].version == "0.0.1"
 
 
-def test_parse_order_by(session):
-    with pytest.raises(NotImplementedError) as e_info:
-        db.parse_order_by()
-
-
-def test_do_search(session):
-    with pytest.raises(NotImplementedError) as e_info:
-        db.do_search()
-
-
 def test_validate_id_and_version(session):
     result_1 = db.validate_id_and_version(session, 'dummy', "0.0.1")
     assert result_1 is True
@@ -204,8 +194,3 @@ def test_delete_version(session):
     db.delete_version(session, pkg_id, '0.0.1')
     assert version_count.scalar() == 0
     assert package_count.scalar() == 0
-
-
-def test_build_in_clause(session):
-    with pytest.raises(NotImplementedError) as e_info:
-        db.build_in_clause()


### PR DESCRIPTION
Renames some DB columns to avoid confusion.

In the NuSpec file, `id` refers to the package's name. When porting simple_nuget_server, I was getting confused between the package name and the database primary key (package_id). This PR renames things to have the Package table looks like so:

```
Package
   package_id int not null
   name varchar(265) not null index
   title varchar(256)            # human-friendly title
   latest_version
```