### PR TITLE
Refactor core file ops

### DIFF
--- a/src/pynuget/core.py
+++ b/src/pynuget/core.py
@@ -198,10 +198,7 @@ def save_file(file, pkg_name, version):
     local_path = local_path / pkg_name / (version + ".nupkg")
 
     # Check if the package's directory already exists. Create if needed.
-    os.makedirs(os.path.split(local_path)[0],
-                mode=0o0755,
-                exist_ok=True,      # do not throw an error path exists.
-                )
+    create_parent_dirs(local_path)
 
     logger.debug("Saving uploaded file to filesystem.")
     try:
@@ -213,6 +210,20 @@ def save_file(file, pkg_name, version):
         logger.info("Succesfully saved package to '%s'" % str(local_path))
 
     return local_path
+
+
+def create_parent_dirs(path):
+    """
+    Create the parent directories if it doesn't already exist.
+
+    Parameters
+    ----------
+    path : :class:`pathlib.Path`
+    """
+    os.makedirs(str(path.parent),
+                mode=0o0755,
+                exist_ok=True,      # do not throw an error path exists.
+                )
 
 
 def extract_nuspec(file):

--- a/src/pynuget/core.py
+++ b/src/pynuget/core.py
@@ -187,16 +187,15 @@ def save_file(file, pkg_name, version):
 
     Returns:
     --------
-    hash_ : bytes
-    filesize
+    local_path : :class:`pathlib.Path`
+        The path to the saved file.
     """
     # Save the package file to the local package dir. Thus far it's
     # just been floating around in magic Flask land.
-    local_path = Path(app.config['SERVER_PATH']) / Path(app.config['PACKAGE_DIR'])
-    local_path = os.path.join(str(local_path),
-                              pkg_name,
-                              version + ".nupkg",
-                              )
+    server_path = Path(app.config['SERVER_PATH'])
+    package_dir = Path(app.config['PACKAGE_DIR'])
+    local_path = server_path / package_dir
+    local_path = local_path / pkg_name / (version + ".nupkg")
 
     # Check if the package's directory already exists. Create if needed.
     os.makedirs(os.path.split(local_path)[0],
@@ -206,12 +205,14 @@ def save_file(file, pkg_name, version):
 
     logger.debug("Saving uploaded file to filesystem.")
     try:
-        file.save(local_path)
+        file.save(str(local_path))
     except Exception as err:       # TODO: specify exceptions
         logger.error("Unknown exception: %s" % err)
         raise err
     else:
-        logger.info("Succesfully saved package to '%s'" % local_path)
+        logger.info("Succesfully saved package to '%s'" % str(local_path))
+
+    return local_path
 
 
 def extract_nuspec(file):

--- a/src/pynuget/core.py
+++ b/src/pynuget/core.py
@@ -139,24 +139,21 @@ def hash_file(file, algorithm=hashlib.md5):
     return m.digest()
 
 
-def hash_and_encode_file(file, pkg_name, version):
+def encode_file(file, hash_):
     """
     Parameters
     ----------
     file : :class:`pathlib.Path` object
-    pkg_name : str
-    version : str
+    hash_ : bytes
+        The value returned by `hash_file()`.
 
     Returns:
     --------
     hash_ : bytes
     filesize : int
     """
-    hash_file(file)
-    logger.debug("Hashing and encoding uploaded file.")
-    a = hash_file(file, hashlib.sha512)
     logger.debug("Encoding in Base64.")
-    hash_ = base64.b64encode(a)
+    hash_ = base64.b64encode(hash_)
 
     # Get the filesize of the uploaded file. Used later.
     filesize = os.path.getsize(file)

--- a/src/pynuget/core.py
+++ b/src/pynuget/core.py
@@ -219,10 +219,10 @@ def extract_nuspec(file):
     """
     Parameters
     ----------
-    file : :class:`werkzeug.datastructures.FileStorage` object or path (str)
+    file : :class:`pathlib.Path` object or str
         The file as retrieved by Flask.
     """
-    pkg = ZipFile(file, 'r')
+    pkg = ZipFile(str(file), 'r')
     logger.debug("Parsing uploaded file.")
     nuspec_file = None
     pattern = re.compile(r'^.*\.nuspec$', re.IGNORECASE)

--- a/src/pynuget/core.py
+++ b/src/pynuget/core.py
@@ -152,45 +152,15 @@ def hash_and_encode_file(file, pkg_name, version):
     hash_ : bytes
     filesize : int
     """
+    hash_file(file)
     logger.debug("Hashing and encoding uploaded file.")
-    with tempfile.TemporaryDirectory() as tmpdir:
-        name = str(uuid4()) + ".tmp"
-        temp_file = os.path.join(tmpdir, name)
-        logger.debug("Saving uploaded file to temporary location.")
-        file.save(temp_file)
-        m = hashlib.sha512()
-        logger.debug("Hashing file.")
-        with open(temp_file, 'rb') as openf:
-            m.update(openf.read())
-        logger.debug("Encoding in Base64.")
-        hash_ = base64.b64encode(m.digest())
+    a = hash_file(file, hashlib.sha512)
+    logger.debug("Encoding in Base64.")
+    hash_ = base64.b64encode(a)
 
-        # Get the filesize of the uploaded file. Used later.
-        filesize = os.path.getsize(temp_file)
-        logger.debug("File size: %d bytes" % filesize)
-
-        # Save the package file to the local package dir. Thus far it's
-        # just been floating around in magic Flask land.
-        local_path = Path(app.config['SERVER_PATH']) / Path(app.config['PACKAGE_DIR'])
-        local_path = os.path.join(str(local_path),
-                                  pkg_name,
-                                  version + ".nupkg",
-                                  )
-
-        # Check if the pacakge's directory already exists. Create if needed.
-        os.makedirs(os.path.split(local_path)[0],
-                    mode=0o0755,
-                    exist_ok=True,      # do not throw an error path exists.
-                    )
-
-        logger.debug("Saving uploaded file to filesystem.")
-        try:
-            shutil.copy(temp_file, local_path)
-        except Exception as err:       # TODO: specify exceptions
-            logger.error("Unknown exception: %s" % err)
-            raise err
-        else:
-            logger.info("Succesfully saved package to '%s'" % local_path)
+    # Get the filesize of the uploaded file. Used later.
+    filesize = os.path.getsize(file)
+    logger.debug("File size: %d bytes" % filesize)
 
     return hash_.decode('utf-8'), filesize
 

--- a/src/pynuget/core.py
+++ b/src/pynuget/core.py
@@ -143,8 +143,7 @@ def hash_and_encode_file(file, pkg_name, version):
     """
     Parameters
     ----------
-    file : :class:`werkzeug.datastructures.FileStorage` object
-        The file as retrieved by Flask.
+    file : :class:`pathlib.Path` object
     pkg_name : str
     version : str
 
@@ -194,6 +193,44 @@ def hash_and_encode_file(file, pkg_name, version):
             logger.info("Succesfully saved package to '%s'" % local_path)
 
     return hash_.decode('utf-8'), filesize
+
+
+def save_file(file, pkg_name, version):
+    """
+    Parameters
+    ----------
+    file : :class:`werkzeug.datastructures.FileStorage` object
+        The file as retrieved by Flask.
+    pkg_name : str
+    version : str
+
+    Returns:
+    --------
+    hash_ : bytes
+    filesize
+    """
+    # Save the package file to the local package dir. Thus far it's
+    # just been floating around in magic Flask land.
+    local_path = Path(app.config['SERVER_PATH']) / Path(app.config['PACKAGE_DIR'])
+    local_path = os.path.join(str(local_path),
+                              pkg_name,
+                              version + ".nupkg",
+                              )
+
+    # Check if the package's directory already exists. Create if needed.
+    os.makedirs(os.path.split(local_path)[0],
+                mode=0o0755,
+                exist_ok=True,      # do not throw an error path exists.
+                )
+
+    logger.debug("Saving uploaded file to filesystem.")
+    try:
+        file.save(local_path)
+    except Exception as err:       # TODO: specify exceptions
+        logger.error("Unknown exception: %s" % err)
+        raise err
+    else:
+        logger.info("Succesfully saved package to '%s'" % local_path)
 
 
 def extract_nuspec(file):

--- a/src/pynuget/core.py
+++ b/src/pynuget/core.py
@@ -112,6 +112,33 @@ def determine_dependencies(metadata_element, namespace):
     return dependencies
 
 
+def hash_file(file, algorithm=hashlib.md5):
+    """
+    Parameters
+    ----------
+    file : :class:`pathlib.Path` object
+    algorithm : Hash algorithm constructor
+        One of the hash algorithms present in the `hashlib` module.
+
+    Returns:
+    --------
+    hash_ : bytes
+
+    Note that the returned `hash_` value is in binary. To make it a human
+    readable string, use `binascii.hexlify(hash_).decode('utf-8')`.
+    """
+    file = str(file)
+    logger.debug("Hashing file %s" % file)
+    m = algorithm()
+    with open(file, 'rb') as openf:
+        m.update(openf.read())
+    hash_ = m.hexdigest()
+
+    logger.debug("%s hash: %s, %s" % (algorithm.__name__, hash_, file))
+
+    return m.digest()
+
+
 def hash_and_encode_file(file, pkg_name, version):
     """
     Parameters

--- a/src/pynuget/core.py
+++ b/src/pynuget/core.py
@@ -112,6 +112,20 @@ def determine_dependencies(metadata_element, namespace):
     return dependencies
 
 
+def hash_and_encode_file(file):
+    """
+    Parameters
+    ----------
+    file : :class:`pathlib.Path` object
+
+    Returns:
+    --------
+    hash_ : bytes
+    filesize : int
+    """
+    return encode_file(file, hash_file(file, hashlib.sha512))
+
+
 def hash_file(file, algorithm=hashlib.md5):
     """
     Parameters

--- a/src/pynuget/routes.py
+++ b/src/pynuget/routes.py
@@ -137,12 +137,8 @@ def push():
     try:
         # rename our file.
         # Check if the package's directory already exists. Create if needed.
-        import os
         new = file.parent.parent / pkg_name / (version + ".nupkg")
-        os.makedirs(os.path.split(str(new))[0],
-                    mode=0o0755,
-                    exist_ok=True,      # do not throw an error path exists.
-                    )
+        core.create_parent_dirs(new)
         logger.debug("Renaming %s to %s" % (str(file), new))
         file.rename(new)
         hash_, filesize = core.hash_and_encode_file(str(new))

--- a/src/pynuget/routes.py
+++ b/src/pynuget/routes.py
@@ -135,7 +135,17 @@ def push():
 
     # Hash the uploaded file and encode the hash in Base64. For some reason.
     try:
-        hash_, filesize = core.hash_and_encode_file(file, pkg_name, version)
+        # rename our file.
+        # Check if the package's directory already exists. Create if needed.
+        import os
+        new = file.parent.parent / pkg_name / (version + ".nupkg")
+        os.makedirs(os.path.split(str(new))[0],
+                    mode=0o0755,
+                    exist_ok=True,      # do not throw an error path exists.
+                    )
+        logger.debug("Renaming %s to %s" % (str(file), new))
+        file.rename(new)
+        hash_, filesize = core.hash_and_encode_file(str(new))
     except Exception as err:
         logger.error("Exception: %s" % err)
         return "api_error: Unable to save file", 500

--- a/src/pynuget/routes.py
+++ b/src/pynuget/routes.py
@@ -3,6 +3,7 @@
 """
 import re
 from pathlib import Path
+from uuid import uuid4
 
 # Third-Party
 from flask import g
@@ -96,6 +97,9 @@ def push():
         logger.error("Package file was not uploaded.")
         return "error: File not uploaded", 409
     file = request.files['package']
+
+    # Save the file to a temporary location
+    file = core.save_file(file, "_temp", str(uuid4()))
 
     # Open the zip file that was sent and extract out the .nuspec file."
     try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@
 """
 import os
 import shutil
+from binascii import hexlify
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -54,6 +55,20 @@ def test_et_to_str():
     assert core.et_to_str(node) is None
     node = MagicMock(text="Hello")
     assert core.et_to_str(node) == "Hello"
+
+
+def test_hash_file():
+    file = Path(DATA_DIR) / "NuGetTest.0.0.1.nupkg"
+    hash_ = core.hash_file(file)
+    assert isinstance(hash_, bytes)
+    in_hex = hexlify(hash_).decode('utf-8')
+    assert in_hex == 'c51fc4294f82ddccfe7026f62bbb3089'
+
+    import hashlib
+    hash_ = core.hash_file(file, hashlib.sha512)
+    assert isinstance(hash_, bytes)
+    in_hex = hexlify(hash_).decode('utf-8')
+    assert in_hex.startswith("3e479fa121a7b19f9f5eed")
 
 
 def test_parse_nuspec():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -115,10 +115,8 @@ def test_hash_and_encode_file():
     version = '0.0.1'
 
     good = os.path.join(DATA_DIR, "good.nupkg")
-    with open(good, 'rb') as openf:
-        file = FileStorage(openf)
 
-        hash_, filesize = core.hash_and_encode_file(file, pkg_name, version)
+    hash_, filesize = core.hash_and_encode_file(good, pkg_name, version)
     assert isinstance(hash_, str)
     assert isinstance(filesize, int)
     assert filesize == 3255

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -121,11 +121,10 @@ def test_hash_and_encode_file():
     app.config['SERVER_PATH'] = DATA_DIR
     app.config['PACKAGE_DIR'] = '.'
     pkg_name = 'DummyPackage'
-    version = '0.0.1'
 
     good = os.path.join(DATA_DIR, "good.nupkg")
 
-    hash_, filesize = core.hash_and_encode_file(good, pkg_name, version)
+    hash_, filesize = core.hash_and_encode_file(good)
     assert isinstance(hash_, str)
     assert isinstance(filesize, int)
     assert filesize == 3255

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,6 +71,15 @@ def test_hash_file():
     assert in_hex.startswith("3e479fa121a7b19f9f5eed")
 
 
+def test_encode_file():
+    good = os.path.join(DATA_DIR, "good.nupkg")
+
+    hash_, filesize = core.encode_file(good, b"aaa")
+    assert isinstance(hash_, str)
+    assert isinstance(filesize, int)
+    assert filesize == 3255
+
+
 def test_parse_nuspec():
     no_metadata = et.parse(os.path.join(DATA_DIR, "no_metadata.nuspec"))
     with pytest.raises(core.ApiException):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,6 +71,15 @@ def test_hash_file():
     assert in_hex.startswith("3e479fa121a7b19f9f5eed")
 
 
+def test_save_file():
+    good = os.path.join(DATA_DIR, "good.nupkg")
+    with open(good, 'rb') as openf:
+        file = FileStorage(openf)
+
+        path = core.save_file(file, "a", "b")
+        path.unlink()
+
+
 def test_encode_file():
     good = os.path.join(DATA_DIR, "good.nupkg")
 


### PR DESCRIPTION
Don't use the `tempfile` module. For some reason, something I was doing with that was causing the md5 hash of the file to change and `nuget install` was getting an error about the "Offset to Central Directory cannot be held in an Int64".

🤷‍♂️ 