### PR TITLE
Correctly delete package from db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 + Optionally run coverage when running in localhost development.
 + Fixed an issue where files with dependencies would break the "List" nuget
   command (#39)
++ Fixed an issue where deleting the last remaining version of a package
+  would not delete the row in the Package table, thus causing subsequet pushes
+  of the same version to fail. (#38)
 
 
 ## 0.2.1 (2018-07-25)

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -330,10 +330,10 @@ def delete_version(session, package_name, version):
            .filter(Package.name == package_name)
            .filter(Version.version == version)
            )
-    pkg = sql.one().package
-    logger.debug(pkg)
+    version = sql.one()
+    pkg = version.package
 
-    session.delete(sql.one())
+    session.delete(version)
 
     # update the Package.latest_version value, or delete the Package
     versions = (session.query(Version)

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -343,5 +343,6 @@ def delete_version(session, package_name, version):
     if len(versions) > 0:
         pkg.latest_version = max(v.version for v in versions)
     else:
+        logger.info("No more versions exist. Deleting package %s" % pkg)
         session.delete(pkg)
     session.commit()

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -330,8 +330,8 @@ def delete_version(session, package_name, version):
            .filter(Package.name == package_name)
            .filter(Version.version == version)
            )
-    package = sql.one().package
-    logger.debug(package)
+    pkg = sql.one().package
+    logger.debug(pkg)
 
     session.delete(sql.one())
 
@@ -341,7 +341,7 @@ def delete_version(session, package_name, version):
                 .filter(Package.name == package_name)
                 ).all()
     if len(versions) > 0:
-        package.latest_version = max(v.version for v in versions)
+        pkg.latest_version = max(v.version for v in versions)
     else:
-        session.delete(package)
+        session.delete(pkg)
     session.commit()

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -338,6 +338,7 @@ def delete_version(session, package_name, version):
 
     # update the Package.latest_version value, or delete the Package
     versions = (session.query(Version)
+                .join(Package)
                 .filter(Package.name == package_name)
                 ).all()
     if len(versions) > 0:

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -73,7 +73,7 @@ class Version(Base):
     package = relationship("Package", backref="versions")
 
     def __repr__(self):
-        return "<Version({}, {})>".format(self.package.name, self.version)
+        return "<Version({}, {}, {})>".format(self.version_id, self.package.name, self.version)
 
     @hybrid_property
     def thing(self):

--- a/src/pynuget/db.py
+++ b/src/pynuget/db.py
@@ -334,7 +334,6 @@ def delete_version(session, package_name, version):
     logger.debug(package)
 
     session.delete(sql.one())
-    session.commit()
 
     # update the Package.latest_version value, or delete the Package
     versions = (session.query(Version)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -150,22 +150,46 @@ def test_insert_version(session):
 
 
 def test_delete_version(session):
+    # Add additional dummy data.
+    pkg = db.Package(name="Foo", latest_version="0.9.6")
+    session.add(pkg)
+    session.commit()
+
+    session.add(db.Version(package_id=pkg.package_id, version="0.9.6"))
+    session.add(db.Version(package_id=pkg.package_id, version="0.9.7"))
+    session.commit()
+
+    # The package we're interested in.
+    pkg_id = 'dummy'
+
     # get our initial counts
-    version_count = session.query(sa.func.count(db.Version.version_id))
+    version_count = (session.query(sa.func.count(db.Version.version_id))
+                     .join(db.Package)
+                     .filter(db.Package.name == pkg_id))
     package_count = session.query(sa.func.count(db.Package.package_id))
     initial_version_count = version_count.scalar()
     initial_package_count = package_count.scalar()
 
-    # Delete a version
-    pkg_id = 'dummy'
     db.delete_version(session, pkg_id, '0.0.2')
 
+    # The number of versions for our package should have decreased by 1.
     assert initial_version_count - 1 == version_count.scalar()
+
+    # We should still have 2 packages
+    assert initial_package_count == 2
     assert initial_package_count == package_count.scalar()
+
+    # The deleted version should not show up at all. (Note this particular
+    # test only works because our dummy data only has 1 instance of "0.0.2")
     assert '0.0.2' not in session.query(db.Version.version).all()
 
-    # twice more, the 2nd of which should delete the package
+    # Deleting the highest version should change the `latest_version` value
+    qry = session.query(db.Package).filter(db.Package.name == 'dummy')
     db.delete_version(session, pkg_id, '0.0.3')
+    assert qry.one().latest_version == '0.0.1'
+
+    # Deleting the last version of a package should remove the row from the
+    # Packages table.
     db.delete_version(session, pkg_id, '0.0.1')
     assert version_count.scalar() == 0
-    assert package_count.scalar() == 0
+    assert package_count.scalar() == 1


### PR DESCRIPTION
Fixes #38 - turns out I forgot to join to the `Package` table.

Also implements some cleanup of the `delete_version` code.